### PR TITLE
Fr/#41/run mediasoup container

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -40,7 +40,8 @@ services:
       - "10000-10100:10000-10100/udp" # RTC用ポート範囲
     environment:
       - PORT=3001
-      - ANNOUNCED_IP=0.0.0.0  # 全てのIPアドレスからのアクセスを許可
+      - DOCKER_ENV=true
+      - HOST_IP=${HOST_IP:-192.168.1.100}  # ホストマシンのローカルIPアドレス
     networks:
       - transcendence_net
     restart: unless-stopped

--- a/secrets/.env.example
+++ b/secrets/.env.example
@@ -44,3 +44,15 @@ HOST="0.0.0.0"
 PORT=3000
 DATABASE_URL="file:./data/auth.db"
 JWT_SECRET="your-secure-jwt-secret-key-should-be-changed-in-production"
+
+# ================================
+# SFU (WebRTC)
+# ================================
+# ローカルネットワーク用設定
+# ホストマシンのローカルIPアドレスを設定してください
+# 例: 192.168.1.100, 192.168.0.100, 10.0.0.100 など
+HOST_IP=192.168.1.100
+
+# SFU用設定
+ANNOUNCED_IP=
+DOCKER_ENV=true

--- a/services/frontend/srcs/utils/multiplayerService.ts
+++ b/services/frontend/srcs/utils/multiplayerService.ts
@@ -67,8 +67,8 @@ export class MultiplayerService {
     const getSFUServerUrl = () => {
       // 本番環境の場合
       if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
-        // HTTPSの場合はwssを使用、HTTPの場合はwsを使用
-        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        // HTTPSの場合はhttpsを使用、HTTPの場合はhttpを使用
+        const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
         const hostname = window.location.hostname;
         const port = '3001';
         return `${protocol}//${hostname}:${port}`;
@@ -83,7 +83,16 @@ export class MultiplayerService {
     // SFUサーバーに接続
     this.socket = io(sfuUrl, {
       transports: ['websocket', 'polling'],
-      autoConnect: false
+      autoConnect: false,
+      // 自己署名証明書対応
+      rejectUnauthorized: false,
+      // 追加のSSL設定
+      secure: true,
+      forceNew: true,
+      reconnection: true,
+      timeout: 5000,
+      // CORS設定
+      withCredentials: true
     });
 
     this.socket.on('connect', () => {

--- a/services/sfu/Dockerfile
+++ b/services/sfu/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     g++ \
     pkg-config \
     libssl-dev \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 # package.jsonとpackage-lock.jsonをコピー
@@ -21,11 +22,15 @@ RUN npm install --verbose
 # TypeScript設定ファイルをコピー
 COPY tsconfig.json ./
 
-# ソースコードをコピー
+# ソースコードとスクリプトをコピー
 COPY src/ ./src/
+COPY scripts/ ./scripts/
 
 # TypeScriptをビルド
 RUN npm run build
+
+# SSL証明書を生成
+RUN chmod +x ./scripts/generate-ssl-certs.sh && ./scripts/generate-ssl-certs.sh
 
 # 本番用ユーザーを作成
 RUN addgroup --gid 1001 nodejs

--- a/services/sfu/package.json
+++ b/services/sfu/package.json
@@ -14,7 +14,9 @@
     "socket.io": "^4.7.4",
     "fastify": "^4.24.3",
     "@fastify/cors": "^8.4.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "https": "^1.0.0",
+    "fs": "^0.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/services/sfu/scripts/generate-ssl-certs.sh
+++ b/services/sfu/scripts/generate-ssl-certs.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# SSL証明書生成スクリプト
+CERT_DIR="/app/certs"
+mkdir -p $CERT_DIR
+
+# 自己署名証明書を生成
+openssl req -x509 -newkey rsa:4096 -keyout $CERT_DIR/server.key -out $CERT_DIR/server.crt -days 365 -nodes -subj "/C=JP/ST=Tokyo/L=Tokyo/O=42Tokyo/OU=ft_transcendence/CN=localhost"
+
+# IP SANsを含む証明書を生成（ローカルネットワーク用）
+cat > $CERT_DIR/san.conf << EOF
+[req]
+default_bits = 4096
+prompt = no
+distinguished_name = dn
+req_extensions = v3_req
+
+[dn]
+C=JP
+ST=Tokyo
+L=Tokyo
+O=42Tokyo
+OU=ft_transcendence
+CN=localhost
+
+[v3_req]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+DNS.2 = *.localhost
+IP.1 = 127.0.0.1
+IP.2 = 0.0.0.0
+IP.3 = 10.16.2.9
+IP.4 = 192.168.1.100
+EOF
+
+# IP SANs付きの証明書を生成
+openssl req -x509 -newkey rsa:4096 -keyout $CERT_DIR/server-san.key -out $CERT_DIR/server-san.crt -days 365 -nodes -config $CERT_DIR/san.conf -extensions v3_req
+
+echo "SSL certificates generated in $CERT_DIR"
+ls -la $CERT_DIR


### PR DESCRIPTION
41

## Summary
This pull request introduces several changes to enhance the security, scalability, and configuration of the SFU (Selective Forwarding Unit) server and its associated services. Key updates include support for SSL certificates, improved Docker environment handling, and local network configuration adjustments.

### Security Enhancements:
* [`services/sfu/Dockerfile`](diffhunk://#diff-87add1120e9d6633413a3b415e0c0c0557099fe46ac6a18155747ae614054480R13): Added a script to generate SSL certificates and included `openssl` in the dependencies. This ensures secure communication via HTTPS and WSS. [[1]](diffhunk://#diff-87add1120e9d6633413a3b415e0c0c0557099fe46ac6a18155747ae614054480R13) [[2]](diffhunk://#diff-87add1120e9d6633413a3b415e0c0c0557099fe46ac6a18155747ae614054480L24-R34)
* [`services/sfu/src/server.ts`](diffhunk://#diff-909ada733fefaa845c4936e87e276ec052de6470808cc75e63ab6b32c2cf011aR6-R32): Implemented SSL certificate handling for the Fastify server, enabling HTTPS and WSS connections when certificates are available. Added fallback to HTTP if certificates are missing. [[1]](diffhunk://#diff-909ada733fefaa845c4936e87e276ec052de6470808cc75e63ab6b32c2cf011aR6-R32) [[2]](diffhunk://#diff-909ada733fefaa845c4936e87e276ec052de6470808cc75e63ab6b32c2cf011aR284-R294)
* [`services/frontend/srcs/utils/multiplayerService.ts`](diffhunk://#diff-5bba016844cf432b6e722cc17638803d6fa2b4dbec6770782ba713376e438afbL86-R95): Updated WebSocket connection settings to include additional SSL-related configurations such as `secure`, `rejectUnauthorized`, and `withCredentials`.

### Docker and Local Network Configuration:
* [`compose.yml`](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L43-R44): Replaced `ANNOUNCED_IP` with `DOCKER_ENV` and `HOST_IP` for better handling of Docker environments and local network configurations.
* [`services/sfu/src/mediasoup-service.ts`](diffhunk://#diff-7b6108576aeae421a49bb74d97798005c63368db33c36181863f77cb4a04104aL96-R119): Enhanced `listenIps` configuration to dynamically include local IP addresses and handle Docker environments. Added a utility method to retrieve the host's local IP address. [[1]](diffhunk://#diff-7b6108576aeae421a49bb74d97798005c63368db33c36181863f77cb4a04104aL96-R119) [[2]](diffhunk://#diff-7b6108576aeae421a49bb74d97798005c63368db33c36181863f77cb4a04104aR304-R320)

### Dependency Updates:
* [`services/sfu/package.json`](diffhunk://#diff-2484fbd1e294878d013a21248195c43d19b26f87e6f78cfbd65afdc6daac0a28L17-R19): Added `https` and `fs` modules to support SSL certificate handling.

### Example Configuration:
* [`secrets/.env.example`](diffhunk://#diff-48894be69e22a3128e18521cb79978fa090dc734238200d945cc4d50be7e051aR47-R58): Added example environment variables for local network and Docker configurations, including `HOST_IP`, `ANNOUNCED_IP`, and `DOCKER_ENV`.

### Protocol Adjustments:
* [`services/frontend/srcs/utils/multiplayerService.ts`](diffhunk://#diff-5bba016844cf432b6e722cc17638803d6fa2b4dbec6770782ba713376e438afbL70-R71): Changed the protocol for SFU server URLs from `wss`/`ws` to `https`/`http` for consistency with SSL support.