### PR TITLE
fix: Remove unnecessary script directory copy from Dockerfile

### DIFF
--- a/services/sfu/Dockerfile
+++ b/services/sfu/Dockerfile
@@ -24,7 +24,6 @@ COPY services/sfu/tsconfig.json ./
 
 # ソースコードとスクリプトをコピー
 COPY services/sfu/src/ ./src/
-COPY services/sfu/scripts/ ./scripts/
 
 # SSL証明書ディレクトリを作成（権限も設定）
 RUN mkdir -p /app/certs /app/internal-certs && chmod 755 /app/certs /app/internal-certs


### PR DESCRIPTION
#87

## Summary
This pull request includes a small change to the `services/sfu/Dockerfile`. The change removes the line that copies the `services/sfu/scripts/` directory into the Docker image, likely because it is no longer needed.
