### PR TITLE
feat: Add host IP display to up and start commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ up:
 	fi
 	docker compose -f $(COMPOSE_FILE) --project-name $(PROJECT_NAME) --env-file $(ENV_FILE) up --build -d
 	@printf "\e[32m🏠 https://localhost:8443/ on nginx\e[m\n"
+	@printf "\e[32m🏓 https://$(shell grep HOST_IP $(ENV_FILE) | cut -d '=' -f2):8443/ on nginx\e[m\n"
 
 build:
 	@echo "Building $(PROJECT_NAME) services..."
@@ -24,6 +25,7 @@ start:
 	@echo "Starting $(PROJECT_NAME) services (without rebuilding)..."
 	docker compose -f $(COMPOSE_FILE) --project-name $(PROJECT_NAME) --env-file $(ENV_FILE) up -d
 	@printf "\e[32m🏠 https://localhost:8443/ on nginx\e[m\n"
+	@printf "\e[32m🏓 https://$(shell grep HOST_IP $(ENV_FILE) | cut -d '=' -f2):8443/ on nginx\e[m\n"
 
 down:
 	@echo "Stopping $(PROJECT_NAME) services..."


### PR DESCRIPTION
#90


## Summary
This pull request updates the `Makefile` to enhance user feedback by including an additional URL for accessing the application based on the `HOST_IP` environment variable. The changes ensure that both the localhost URL and the `HOST_IP`-based URL are displayed when starting or bringing up the services.

Enhancements to user feedback:

* `Makefile` (`up:`): Added a new line to print the application URL using the `HOST_IP` environment variable, providing an alternative to the localhost URL.
* `Makefile` (`start:`): Similarly, added a new line to display the `HOST_IP`-based URL when starting services without rebuilding.