### PR TITLE
fix: Update button hover effects to use opacity transition for a smoo…

### DIFF
--- a/services/frontend/srcs/pages/Home.tsx
+++ b/services/frontend/srcs/pages/Home.tsx
@@ -91,7 +91,7 @@ const Home: React.FC<HomeProps> = ({ navigate }) => {
           {/* Icons positioned in plus shape - doubled size */}
           <button
             onClick={handleGoogleAuth}
-            className="absolute top-0 left-1/2 transform -translate-x-1/2 hover:bg-slate-100 rounded transition-colors p-2"
+            className="absolute top-0 left-1/2 transform -translate-x-1/2 hover:opacity-80 transition-opacity p-2"
             aria-label="Sign in with Google"
           >
             <img src="/images/icons/google.svg" alt="Google Sign In" className="w-14 h-14" />
@@ -99,7 +99,7 @@ const Home: React.FC<HomeProps> = ({ navigate }) => {
 
           <button
             onClick={() => navigate('UserRegistration')}
-            className="absolute right-0 top-1/2 transform -translate-y-1/2 hover:bg-slate-100 rounded transition-colors p-2"
+            className="absolute right-0 top-1/2 transform -translate-y-1/2 hover:opacity-80 transition-opacity p-2"
             aria-label="Sign Up"
           >
             <img src="/images/icons/signup.svg" alt="Sign Up" className="w-14 h-14" />
@@ -107,7 +107,7 @@ const Home: React.FC<HomeProps> = ({ navigate }) => {
 
           <button
             onClick={() => navigate('EmailVerification')}
-            className="absolute left-0 top-1/2 transform -translate-y-1/2 hover:bg-slate-100 rounded transition-colors p-2"
+            className="absolute left-0 top-1/2 transform -translate-y-1/2 hover:opacity-80 transition-opacity p-2"
             aria-label="Sign In"
           >
             <img src="/images/icons/signin.svg" alt="Sign In" className="w-14 h-14" />
@@ -115,7 +115,7 @@ const Home: React.FC<HomeProps> = ({ navigate }) => {
 
           <button
             onClick={toggleMute}
-            className="absolute bottom-0 left-1/2 transform -translate-x-1/2 hover:bg-slate-100 rounded transition-colors p-2"
+            className="absolute bottom-0 left-1/2 transform -translate-x-1/2 hover:opacity-80 transition-opacity p-2"
             aria-label={isMuted ? "Unmute" : "Mute"}
           >
             <img
@@ -131,7 +131,7 @@ const Home: React.FC<HomeProps> = ({ navigate }) => {
       {showSkipButton && (
         <button
           onClick={() => navigate('GameSelect')}
-          className="absolute bottom-4 right-4 bg-slate-100 hover:bg-slate-200 text-slate-700 px-4 py-2 rounded border transition-colors"
+          className="absolute bottom-4 right-4 bg-slate-100 hover:opacity-80 transition-opacity text-slate-700 px-4 py-2 rounded border"
           aria-label="Skip to GameSelect"
         >
           skip


### PR DESCRIPTION
…ther UI experience

#102 


## Summary
This pull request updates the styling of buttons on the `Home` page in the frontend to improve hover effects by replacing background color changes with opacity transitions. This simplifies the visual feedback while maintaining a clean and modern design.

### Styling Updates:

* Updated hover effects for multiple buttons (`Sign in with Google`, `Sign Up`, `Sign In`, and `Mute/Unmute`) to use `hover:opacity-80` and `transition-opacity` instead of `hover:bg-slate-100` and `transition-colors`. This change affects buttons positioned in a "plus" shape on the screen. (`services/frontend/srcs/pages/Home.tsx`, [services/frontend/srcs/pages/Home.tsxL94-R118](diffhunk://#diff-de2b9389ddec69a9090ce51fca62551707ea2c27c1011384f1a9d92591f31ea1L94-R118))
* Modified the `Skip to GameSelect` button to use `hover:opacity-80` and `transition-opacity` instead of `hover:bg-slate-200` and `transition-colors` for a consistent hover effect across the page. (`services/frontend/srcs/pages/Home.tsx`, [services/frontend/srcs/pages/Home.tsxL134-R134](diffhunk://#diff-de2b9389ddec69a9090ce51fca62551707ea2c27c1011384f1a9d92591f31ea1L134-R134))
